### PR TITLE
Updates to mpi_wrapper interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json
+.clangd
 CTestTestfile.cmake
 _deps
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+# add our cmake module directory to the path
+set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+     "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 project(icaruswf LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cmake/FindTCLAP.cmake
+++ b/cmake/FindTCLAP.cmake
@@ -1,0 +1,29 @@
+# thanks to HEPnOS-PEP-Benchmark!
+# - Find TCLAP
+# Find the TCLAP headers
+#
+# TCLAP_INCLUDE_DIR - where to find the TCLAP headers
+# TCLAP_FOUND       - True if TCLAP is found
+
+if (TCLAP_INCLUDE_DIR)
+  # already in cache, be silent
+  set (TCLAP_FIND_QUIETLY TRUE)
+endif (TCLAP_INCLUDE_DIR)
+
+# find the headers
+find_path (TCLAP_INCLUDE_PATH tclap/CmdLine.h
+  PATHS
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_INSTALL_PREFIX}/include
+  )
+
+# handle the QUIETLY and REQUIRED arguments and set TCLAP_FOUND to
+# TRUE if all listed variables are TRUE
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (TCLAP "TCLAP (http://tclap.sourceforge.net/) could not be found. Set TCLAP_INCLUDE_PATH to point to the headers adding '-DTCLAP_INCLUDE_PATH=/path/to/tclap' to the cmake command." TCLAP_INCLUDE_PATH)
+
+if (TCLAP_FOUND)
+  set (TCLAP_INCLUDE_DIR ${TCLAP_INCLUDE_PATH})
+endif (TCLAP_FOUND)
+
+mark_as_advanced(TCLAP_INCLUDE_PATH)

--- a/scripts/csresearch00/run_icaruswf_hepnos_mpi_dist_queue_bench.sh
+++ b/scripts/csresearch00/run_icaruswf_hepnos_mpi_dist_queue_bench.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+export MPICH_MAX_THREAD_SAFETY=multiple
+
+# activate spack environment
+. /scratch/gartung/spack/share/spack/setup-env.sh
+spack load gcc@9.3.0
+spack env activate icaruscode-09_37_02_vecmt04-hepnos-0_7_0
+export ICARUSWF_SRC=/nashome/s/sasyed/packages/icaruswf
+. ${ICARUSWF_SRC}/envvariable.sh
+
+export ICARUSWF_BUILD=/nashome/s/sasyed/packages/icaruswf/build
+export CET_PLUGIN_PATH=${ICARUSWF_BUILD}/src/modules:${CET_PLUGIN_PATH}
+export FHICL_FILE_PATH=${ICARUSWF_BUILD}/fcl:${FHICL_FILE_PATH}
+
+export DATA_DIR=/scratch/cerati/icaruscode-v09_37_01_02p02/icaruscode-09_37_01_02p02-samples
+# for geometry files!
+export FW_SEARCH_PATH=${FW_SEARCH_PATH}:/scratch/gartung/spack/opt/spack/linux-scientific7-x86_64_v2/gcc-9.3.0/icarusalg-09.37.02.01-tyt7hh6cyhthdx5ut6ngugcrdybpgclw/gdml
+# for pandora xml file
+export FW_SEARCH_PATH=${FW_SEARCH_PATH}:/scratch/gartung/spack/var/spack/environments/icaruscode-09_37_02_vecmt04-hepnos-0_7_0/.spack-env/view/fw
+
+# collect diagnostic profiles
+export MARGO_ENABLE_DIAGNOSTICS=0
+export MARGO_ENABLE_PROFILING=0
+
+# number of events to upload and process
+export NUM_EVENTS=100
+
+export BASEDIR=$(pwd)
+export THREADS=4
+
+# start the hepnos server
+echo "%%% before starting HEPnOS server for run with with $THREADS threads, at $(date)"
+# 2 nodes for server, 8 MPI ranks per node
+mpiexec -iface ib0 -f hostfile_server -np 16 bedrock ofi+tcp -c hepnos.json -v trace &> server-log &
+sleep 30
+hepnos-list-databases ofi+tcp -s hepnos.ssg > connection.json
+echo "%%% after starting HEPnOS server for run with with $THREADS threads, at $(date)"
+
+# Create queues
+echo "%%% before creating queues for run with with $THREADS threads, at $(date)"
+${ICARUSWF_BUILD}/src/modules/cheesyQueue_maker ofi+tcp connection.json DetSim HitFinding
+echo "%%% after creating queues for run with with $THREADS threads, at $(date)"
+
+# Load Data
+echo "%%% before loading data, at $(date)"
+# 5 nodes for client, 20 MPI ranks per node
+mpiexec -iface ib0 -f hostfile_client -np 100 ${ICARUSWF_BUILD}/src/modules/mpi_wrapper -l --num_evts_per_rank 1 --root_file_path /wclustre/fwk/sajid/detsim_00.root &> load_00_log
+mpiexec -iface ib0 -f hostfile_client -np 100 ${ICARUSWF_BUILD}/src/modules/mpi_wrapper -l --num_evts_per_rank 1 --root_file_path /wclustre/fwk/sajid/detsim_01.root &> load_01_log
+echo "%%% after loading data, at $(date)"
+
+# Process Data 
+echo "%%% before processing data $(date)"
+# 5 nodes for client, 8 MPI ranks per node, 4 threads per MPI rank, 5 events per MPI rank
+mpiexec -iface ib0 -f hostfile_client -np 40 ${ICARUSWF_BUILD}/src/modules/mpi_wrapper -p -t 4 --num_evts_per_rank 5 &> process_log
+echo "%%% after processing data $(date)"
+
+# Shutdown the HEPnOS server
+echo "%%% before shutting down HEPnOS server for run with $THREADS threads, at $(date)"
+hepnos-shutdown ofi+tcp connection.json
+echo "%%% after shutting down HEPnOS server for run with $THREADS threads, at $(date)"

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -18,8 +18,11 @@ target_link_libraries(HepnosDataStore_service PRIVATE Boost::system hepnos Boost
 target_include_directories(HepnosDataStore_service PRIVATE  $ENV{ROOT_INC} $ENV{ART_INC} $ENV{HEPNOS_INC} $ENV{THALLIUM_INC} $ENV{LARDATAOBJ_INC} $ENV{CEREAL_INC} ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+# TCLAP
+find_package(TCLAP REQUIRED)
 add_executable(mpi_wrapper mpi_wrapper.cc)
 target_link_libraries(mpi_wrapper PRIVATE MPI::MPI_C)
+target_include_directories(mpi_wrapper PRIVATE ${TCLAP_INCLUDE_PATH})
 
 add_executable(cheesyQueue_maker cheesyQueue_maker.cc)
 target_include_directories(cheesyQueue_maker PRIVATE ${CMAKE_SOURCE_DIR} $ENV{HEPNOS_INC})

--- a/src/modules/mpi_wrapper.cc
+++ b/src/modules/mpi_wrapper.cc
@@ -2,39 +2,176 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <tclap/CmdLine.h>
+#include <unistd.h>
 
-bool loadData(int my_rank, int nevents){
+bool
+loadData(int my_rank,
+         int nevents,
+         std::string path,
+         std::optional<std::string> env_flags)
+{
   std::string nskip = " --nskip ";
-  nskip += std::to_string(my_rank*nevents);
+  nskip += std::to_string(my_rank * nevents);
   std::string nevts = " -n ";
   nevts += std::to_string(nevents);
-  std::string cmd = "art -c storedata.fcl -s /scratch/cerati/icaruscode-v09_37_01_02p02/icaruscode-09_37_01_02p02-samples/prodcorsika_bnb_genie_protononly_overburden_icarus_20220118T213827-GenBNBbkgr_100evt_G4_DetSim.root " + nevts + nskip;
+  std::string cmd = "";
+  if (env_flags.has_value()) {
+    cmd.append(env_flags.value());
+  }
+  cmd.append("art -c storedata_queue.fcl -s ");
+  cmd.append(path);
+  cmd.append(nevts);
+  cmd.append(nskip);
+  std::string outfile = " &> ";
+  outfile.append(std::to_string(my_rank));
+  outfile.append("_load.txt");
+  cmd.append(outfile);
   std::system(cmd.c_str());
   return true;
 }
 
-bool runSP(int my_rank, int nevents){
-  std::string nskip = " --nskip ";
-  nskip += std::to_string(my_rank*nevents);
+bool
+runSP(int my_rank,
+      int nevents,
+      int nthreads,
+      std::optional<std::string> env_flags)
+{
   std::string nevts = " -n ";
   nevts += std::to_string(nevents);
-  std::string memdb = " --memcheck-db memory_sp_" + std::to_string(my_rank) + ".db";
-  std::string cmd = "art -c sp_hepnos.fcl --timing-db timing_sp_" + std::to_string(my_rank) + ".db" + memdb + nevts + nskip;
+  std::string memdb =
+    " --memcheck-db memory_sp_" + std::to_string(my_rank) + ".db";
+
+  std::string cmd = "";
+  if (env_flags.has_value()) {
+    cmd.append(env_flags.value());
+  }
+  cmd.append("art --nschedules 1 --nthreads " + std::to_string(nthreads) +
+             " -c icarus_SH_queue.fcl "
+             "--timing-db timing_sp_" +
+             std::to_string(my_rank) + ".db" + memdb + nevts);
+  std::string outfile = " &> ";
+  outfile.append(std::to_string(my_rank));
+  outfile.append("_process.txt");
+  cmd.append(outfile);
   std::system(cmd.c_str());
   return true;
 }
 
-int main(int argc, char *argv[]) {
-  Mpi world(argc, argv);
-  auto my_rank = world.rank();
-  auto nranks = world.np();
-  int events = std::atoi(argv[1]); 
-  std::cout << "Loading data by rank "<< my_rank << " of " << nranks << std::endl;
-  loadData(my_rank, events);
-  world.barrier();
-  runSP(my_rank, events);
+int
+main(int argc, char* argv[])
+{
+
+  const std::string default_root_path = "tmp.root";
+
+  try {
+    TCLAP::CmdLine cmd(
+      "ICARUSWF with HEPnOS mpi-wrapper for launching art over MPI!");
+
+    TCLAP::ValueArg<int64_t> nevtsArg(
+      "n",
+      "num_evts_per_rank",
+      "total number of events to process, by each MPI rank",
+      true,
+      0,
+      "int64");
+    cmd.add(nevtsArg);
+
+    TCLAP::ValueArg<std::string> rootfilepathArg(
+      "P",
+      "root_file_path",
+      "location of the ROOT file to process",
+      false,
+      default_root_path,
+      "string");
+    cmd.add(rootfilepathArg);
+
+    TCLAP::ValueArg<int64_t> threadsArg(
+      "t",
+      "threads",
+      "number of threads to use for SH processing",
+      false,
+      1,
+      "int64");
+    cmd.add(threadsArg);
+
+    TCLAP::SwitchArg loadSwitch(
+      "l",
+      "load_events",
+      "Whether to load events to the HEPnOS datastore",
+      cmd,
+      false);
+
+    TCLAP::SwitchArg processSwitch(
+      "p",
+      "process_events",
+      "Whether to process events in the HEPnOS datastore",
+      cmd,
+      false);
+
+    // Parse the argv array.
+    cmd.parse(argc, argv);
+
+    Mpi world(argc, argv);
+    auto my_rank = world.rank();
+    auto nranks = world.np();
+
+    int64_t events = nevtsArg.getValue();
+    bool load_events_to_hepnos = loadSwitch.getValue();
+    std::string root_file_path = rootfilepathArg.getValue();
+    if (load_events_to_hepnos) {
+      if (root_file_path == default_root_path) {
+        std::runtime_error(
+          "please provide the path to the root file to load events from!");
+      }
+    }
+    bool process_events_in_hepnos = processSwitch.getValue();
+    int64_t nthreads = threadsArg.getValue();
+
+    // Confidence check regarding execution resources being used
+    constexpr size_t LEN = 1024;
+    std::string hostname;
+    hostname.reserve(LEN);
+    if (gethostname(hostname.data(), LEN) == 0) {
+      std::string init_message("MPI rank ");
+      init_message.append(std::to_string(my_rank));
+      init_message.append(" of total ");
+      init_message.append(std::to_string(nranks));
+      init_message.append(" ranks is running on ");
+      init_message.append(hostname);
+      std::cout << init_message << "\n";
+    } else {
+      std::cout << "could not determine execution resources being used!"
+                << "\n";
+    }
+    std::optional<std::string> env_flags;
+    if (hostname.find("theta") != std::string::npos) {
+      env_flags.emplace("PMI_NO_PREINITIALIZE=1 PMI_NO_FORK=1");
+    }
+
+    if (load_events_to_hepnos) {
+      if (loadData(my_rank, events, root_file_path, env_flags) != true) {
+        std::runtime_error("loading data into HEPnOS failed!");
+      }
+    }
+
+    // is this necessary?
+    world.barrier();
+
+    if (process_events_in_hepnos) {
+      if (runSP(my_rank, events, nthreads, env_flags) != true) {
+        std::runtime_error("processing data in HEPnOS failed!");
+      }
+    }
+  }
+  catch (TCLAP::ArgException& e) // catch exceptions
+  {
+    std::cerr << "error: " << e.error() << " for arg " << e.argId()
+              << std::endl;
+  }
+
   return 0;
 }
-
-

--- a/src/modules/mpicpp.hpp
+++ b/src/modules/mpicpp.hpp
@@ -2,14 +2,22 @@
 #define MPICPP_HPP
 
 #include "mpi.h"
-#include <iostream>
-#include <unistd.h>
 #include <array>
+#include <iostream>
+#include <stdexcept>
+#include <unistd.h>
 
-template <typename T> struct mpi_type {};
+template <typename T>
+struct mpi_type {};
 
-template <> struct mpi_type<int> {static const MPI_Datatype value = MPI_INT;};
-template <> struct mpi_type<char> {static const MPI_Datatype value = MPI_CHAR;};
+template <>
+struct mpi_type<int> {
+  static const MPI_Datatype value = MPI_INT;
+};
+template <>
+struct mpi_type<char> {
+  static const MPI_Datatype value = MPI_CHAR;
+};
 
 class Mpi {
 public:
@@ -21,16 +29,19 @@ public:
   {
     return rank_;
   }
+
   int
   np() const
   {
     return np_;
   }
+
   int
   hostid() const
   {
     return hostid_;
   }
+
   std::string
   name() const
   {
@@ -42,16 +53,19 @@ public:
   {
     return rank_group_;
   }
+
   int
   np_group() const
   {
     return np_group_;
   }
+
   MPI_Comm
   comm_group() const
   {
     return comm_;
   }
+
   MPI_Comm
   comm() const
   {
@@ -61,13 +75,17 @@ public:
   void barrier();
   void barrier_group();
   template <typename T>
-  int broadcast(T* v, int root) {
-    return MPI_Bcast(v, 1, mpi_type<T>::value, root, MPI_COMM_WORLD);    
+  int
+  broadcast(T* v, int root)
+  {
+    return MPI_Bcast(v, 1, mpi_type<T>::value, root, MPI_COMM_WORLD);
   }
 
   template <std::size_t N, typename T>
-  int broadcast(std::array<T, N>* buffer, int root) {
-     return MPI_Bcast(buffer, N, mpi_type<T>::value, root, MPI_COMM_WORLD);
+  int
+  broadcast(std::array<T, N>* buffer, int root)
+  {
+    return MPI_Bcast(buffer, N, mpi_type<T>::value, root, MPI_COMM_WORLD);
   }
 
 private:
@@ -80,14 +98,22 @@ private:
   MPI_Comm comm_;
 };
 
-inline 
-Mpi::Mpi(int argc, char* argv[])
+inline Mpi::Mpi(int argc, char* argv[])
 {
   int provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-  //assert(provided == MPI_THREAD_MULTIPLE);
-  MPI_Comm_size(MPI_COMM_WORLD, &np_);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank_);
+  if (MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided) !=
+      MPI_SUCCESS) {
+    std::runtime_error("MPI_Init_thread error!");
+  }
+
+  // assert(provided == MPI_THREAD_MULTIPLE);
+
+  if (MPI_Comm_size(MPI_COMM_WORLD, &np_) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Comm_size error!");
+  }
+  if (MPI_Comm_rank(MPI_COMM_WORLD, &rank_) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Comm_rank error!");
+  }
   hostid_ = (unsigned int)(gethostid());
 
   unsigned int group_size = 1;
@@ -96,32 +122,40 @@ Mpi::Mpi(int argc, char* argv[])
 
   int name_sz = 0;
   char name_buf[MPI_MAX_PROCESSOR_NAME];
-  MPI_Get_processor_name(name_buf, &name_sz);
+  if (MPI_Get_processor_name(name_buf, &name_sz) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Get_processor_name error!");
+  }
   name_ = name_buf;
 
-  MPI_Comm_split(MPI_COMM_WORLD, hostid_, rank_, &comm_);
-  MPI_Comm_rank(comm_, &rank_group_);
-  MPI_Comm_size(comm_, &np_group_);
+  if (MPI_Comm_split(MPI_COMM_WORLD, hostid_, rank_, &comm_) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Comm_split error!");
+  }
+  if (MPI_Comm_rank(comm_, &rank_group_) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Comm_rank error");
+  }
+  if (MPI_Comm_size(comm_, &np_group_) != MPI_SUCCESS) {
+    std::runtime_error("MPI_Comm_size error!");
+  }
 }
 
-inline
-Mpi::~Mpi()
+inline Mpi::~Mpi()
 {
-  MPI_Finalize();
+  if (MPI_Finalize() != MPI_SUCCESS)
+    std::runtime_error("MPI_Finalize error!");
 }
 
-inline
-void
+inline void
 Mpi::barrier()
 {
-  MPI_Barrier(MPI_COMM_WORLD);
+  if (MPI_Barrier(MPI_COMM_WORLD) != MPI_SUCCESS)
+    std::runtime_error("Mpi::narrier error!");
 }
 
-inline
-void
+inline void
 Mpi::barrier_group()
 {
-  MPI_Barrier(comm_);
+  if (MPI_Barrier(comm_) != MPI_SUCCESS)
+    std::runtime_error("Mpi::barrier_group error!");
 }
 
 #endif

--- a/wiki/csresearch00.md
+++ b/wiki/csresearch00.md
@@ -8,7 +8,7 @@
 
 4. setup spack: `source /scratch/gartung/spack/share/spack/setup-env.sh`
 
-5. load the compiler via `spack load gcc@9.3.0`; activate spack environment, the current one available on csresearch is: `spack env activate icaruscode-09_37_02_03-hepnos-0_6_10`
+5. load the compiler via `spack load gcc@9.3.0`; activate spack environment, the current one available on csresearch is: `spack env activate icaruscode-09_37_02_vecmt04-hepnos-0_7_0`
 
 6. set up the environment variables: `source ${ICARUSWF_SRC}/envvariable.sh`
 


### PR DESCRIPTION
Updated `mpi_wrapper` interface with example script to run it on `csresearch.wc.fnal.gov`. 

The only outstanding issue is that it fails to print the `hostname` as expected: 
```
MPI rank 12 of total 40 ranks is running on 
MPI rank 19 of total 40 ranks is running on 
```
If this is difficult to fix, we can make the extra environment flags an optional argument instead of relying on being able to detect when we are running on `theta.alcf.anl.gov`